### PR TITLE
Chaning sendRaw() and sendText() argument parsing

### DIFF
--- a/mailgun.js
+++ b/mailgun.js
@@ -93,13 +93,13 @@ Mailgun.prototype.sendText = function(sender, recipients, subject, text) {
   // Flexible argument magic!
   var args = Array.prototype.slice.call(arguments, 4);
   // Pluck servername.
-  if (args[0] && typeof args[0] == 'string')
+  if (args.length && typeof args[0] == 'string')
     servername = args.shift() || servername;
   // Pluck options.
-  if (args[0] && typeof args[0] == 'object')
+  if (args.length && typeof args[0] == 'object')
     options = args.shift() || options;
   // Pluck callback.
-  if (args[0] && typeof args[0] == 'function')
+  if (args.length && typeof args[0] == 'function')
     callback = args.shift() || callback;
   // Don't be messy.
   delete args;
@@ -153,10 +153,10 @@ Mailgun.prototype.sendRaw = function(sender, recipients, rawBody) {
   // Flexible argument magic!
   var args = Array.prototype.slice.call(arguments, 3);
   // Pluck servername.
-  if (args[0] && typeof args[0] == 'string')
+  if (args.length && typeof args[0] == 'string')
     servername = args.shift() || servername;
   // Pluck callback.
-  if (args[0] && typeof args[0] == 'function')
+  if (args.length && typeof args[0] == 'function')
     callback = args.shift() || callback;
   // Don't be messy.
   delete args;


### PR DESCRIPTION
If someone were to pass `''` as a servername, none of the other arguments would get parsed.
This change allows the latter arguments to get parsed.

For example, with the following code, the config object never gets loaded and the callback never runs:

```
var mailgun = new (require('mailgun').Mailgun)(config.mailgun);

mailgun.sendText("me@thomashunter.name", ["tlhunter@gmail.com"], "subj", "dat body", '', {}, function(err) {
  log.info('mail send callback');
});
```

This code not running seems to violate the example in the readme, wherein servername is shown as defaulting to an empty string:

```
sendText(sender, recipients, subject, text, [servername=''], [options={}], [callback(err)])
```
