### PR TITLE
Removed note about templates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,10 +105,6 @@ sendRaw(sender, recipients, rawBody, [servername], [callback(err)])
                 the status code of the API HTTP response code  if the email
                 failed to send; on success, `err` will be `undefined`.
 
-**Note:** Sending a message via raw MIME lets you use Mailgun's built-in
-          templating shinies.  Check out the [Mailgun Docs](http://documentation.mailgun.net/Documentation/DetailedDocsAndAPIReference#Message_Templates)
-          for details.
-
 #### Example
 
 ```js


### PR DESCRIPTION
The link was outdated, the current docs (here: https://documentation.mailgun.com/user_manual.html#batch-sending) never mention the word shinies, and templates don't seem to have to do with the MIMEtype.