### PR TITLE
Add error checking on sender and recipient arguments.

### DIFF
--- a/mailgun.js
+++ b/mailgun.js
@@ -94,7 +94,7 @@ Mailgun.prototype.sendText = function(sender, recipients, subject, text) {
   if (typeof recipients === 'undefined')
     throw new Error('recipients is undefined');
 
-  if (typeof recipients !== 'string' && typeof recipients !== 'array')
+  if (typeof recipients !== 'string' && !(recipients instanceof Array))
     throw new Error('recipients is not a string or an array');
 
   // Less than 4 arguments means we're missing something that prevents
@@ -161,7 +161,7 @@ Mailgun.prototype.sendRaw = function(sender, recipients, rawBody) {
   if (typeof recipients === 'undefined')
     throw new Error('recipients is undefined');
 
-  if (typeof recipients !== 'string' && typeof recipients !== 'array')
+  if (typeof recipients !== 'string' && !(recipients instanceof Array))
     throw new Error('recipients is not a string or an array');
 
   // Less than 3 arguments means we're missing something that prevents

--- a/mailgun.js
+++ b/mailgun.js
@@ -85,6 +85,18 @@ Mailgun.prototype.sendText = function(sender, recipients, subject, text) {
   var options = {};
   var callback = null;
 
+  if (typeof sender === 'undefined')
+    throw new Error('sender is undefined');
+
+  if (typeof sender !== 'string')
+    throw new Error('sender is not a string');
+
+  if (typeof recipients === 'undefined')
+    throw new Error('recipients is undefined');
+
+  if (typeof recipients !== 'string' && typeof recipients !== 'array')
+    throw new Error('recipients is not a string or an array');
+
   // Less than 4 arguments means we're missing something that prevents
   // us from even sending an email, so we fail.
   if (arguments.length < 4)
@@ -139,6 +151,18 @@ Mailgun.prototype.sendRaw = function(sender, recipients, rawBody) {
   // sure they're in scope.
   var servername = '';
   var callback = null;
+
+  if (typeof sender === 'undefined')
+    throw new Error('sender is undefined');
+
+  if (typeof sender !== 'string')
+    throw new Error('sender is not a string');
+
+  if (typeof recipients === 'undefined')
+    throw new Error('recipients is undefined');
+
+  if (typeof recipients !== 'string' && typeof recipients !== 'array')
+    throw new Error('recipients is not a string or an array');
 
   // Less than 3 arguments means we're missing something that prevents
   // us from even sending an email, so we fail.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailgun",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Mailgun for Node.js",
   "author": "shz",
   "repository": {


### PR DESCRIPTION
I had the situation arise where recipients in sendRaw was undefined and my app would crash in mailgun.js. So I added a couple of checks for sender and recipients. The checks for undefined aren't necessary as they would be caught by the subsequent check for string or array, but I thought it may help to be more explicit in those cases.